### PR TITLE
required changes to run the project

### DIFF
--- a/attendance.py
+++ b/attendance.py
@@ -93,7 +93,7 @@ def testVal(inStr, acttyp):
 
 
 logo = Image.open("UI_Image/0001.png")
-logo = logo.resize((50, 47), Image.ANTIALIAS)
+logo = logo.resize((50, 47), Image.Resampling.LANCZOS)
 logo1 = ImageTk.PhotoImage(logo)
 titl = tk.Label(window, bg="black", relief=RIDGE, bd=10, font=("arial", 35))
 titl.pack(fill=X)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+numpy==1.16.1
+opencv-contrib-python==4.2.0.84
+opencv-python==4.2.0.84
+openpyxl==3.1.5
+pandas==2.2.3
+pillow==11.0.0
+pyttsx3==2.71
+
+


### PR DESCRIPTION
ANTIALIAS was removed in Pillow 10.0.0 (after being deprecated through many previous versions). Now you need to use PIL.Image.LANCZOS or PIL.Image.Resampling.LANCZOS.

(This is the exact same algorithm that ANTIALIAS referred to, you just can no longer access it through the name ANTIALIAS.)

And requirements was not named correct.